### PR TITLE
Show account name on the dashboard's recent transactions

### DIFF
--- a/src/app/dashboard/dashboard.html
+++ b/src/app/dashboard/dashboard.html
@@ -59,7 +59,8 @@
           {{recentTx.tx.date | datetz:"M/D":org.timezone}}
         </div>
         <div class="col-5 col-md-6 description">
-          {{recentTx.tx.description}}
+          <div class="primary">{{recentTx.tx.description}}</div>
+          <div class="additional">{{recentTx.account.fullName}}</div>
         </div>
         <div class="col-4 col-md-4 amount" [ngClass]="{'negative': recentTx.split.amount > 0}">
           {{-recentTx.split.amount | currencyFormat:recentTx.account.precision:recentTx.account.currency}}

--- a/src/app/dashboard/dashboard.scss
+++ b/src/app/dashboard/dashboard.scss
@@ -41,6 +41,19 @@
   .expanded .hidden {
     display: flex
   }
+  .row {
+    padding-bottom: 1em;
+    .description {
+      .primary:empty::after {
+        content: ".";
+        visibility: hidden;
+      }
+      .additional {
+        font-size: small;
+        color: $black;
+      }
+    }
+  }
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
If a transaction description is brief, it is useful to provide context by showing the account name.

Note: this commit isn't ideal since it doesn't show all the accounts involved for a given transaction. This might however be good enough for now.

Before:
<img width="1792" alt="Screenshot 2023-11-20 at 6 18 16 PM" src="https://github.com/openaccounting/oa-web/assets/441307/19667dcf-898b-4ac3-96f7-2ab7fc7c8acc">

After:
<img width="1792" alt="Screenshot 2023-11-20 at 6 16 35 PM" src="https://github.com/openaccounting/oa-web/assets/441307/ad0a430e-dfe1-4812-96ea-727ea31f15c5">
